### PR TITLE
Audited verifier_groth.sol

### DIFF
--- a/phase2/src/circom_circuit.rs
+++ b/phase2/src/circom_circuit.rs
@@ -203,7 +203,7 @@ pub fn create_verifier_sol(params: &Parameters<Bn256>) -> String {
     let p1_to_str = |p: &<Bn256 as Engine>::G1Affine| {
         let x = repr_to_big(p.get_x().into_repr());
         let y = repr_to_big(p.get_y().into_repr());
-        return format!("{}, {}", x, y)
+        return format!("uint256({}), uint256({})", x, y)
     };
     let p2_to_str = |p: &<Bn256 as Engine>::G2Affine| {
         let x = p.get_x();
@@ -212,7 +212,7 @@ pub fn create_verifier_sol(params: &Parameters<Bn256>) -> String {
         let x_c1 = repr_to_big(x.c1.into_repr());
         let y_c0 = repr_to_big(y.c0.into_repr());
         let y_c1 = repr_to_big(y.c1.into_repr());
-        format!("[{}, {}], [{}, {}]", x_c1, x_c0, y_c1, y_c0)
+        format!("[uint256({}), uint256({})], [uint256({}), uint256({})]", x_c1, x_c0, y_c1, y_c0)
     };
 
     let template = template.replace("<%vk_alfa1%>", &*p1_to_str(&params.vk.alpha_g1));

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -17,7 +17,7 @@
 
 // 2019 OKIMS
 
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 library Pairing {
 
@@ -48,7 +48,7 @@ library Pairing {
     }
 
     /*
-     * @return The sum of two points of G1
+     * @return r the sum of two points of G1
      */
     function plus(
         G1Point memory p1,
@@ -64,7 +64,7 @@ library Pairing {
 
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 6, input, 0xc0, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
@@ -73,7 +73,7 @@ library Pairing {
     }
 
     /*
-     * @return The product of a point on G1 and a scalar, i.e.
+     * @return r the product of a point on G1 and a scalar, i.e.
      *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
      *         points p.
      */
@@ -86,7 +86,7 @@ library Pairing {
         bool success;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 7, input, 0x80, r, 0x60)
+            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
@@ -130,7 +130,7 @@ library Pairing {
 
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas, 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -1,225 +1,229 @@
-//
 // Copyright 2017 Christian Reitwiessner
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
 // 2019 OKIMS
-//      ported to solidity 0.5
-//      fixed linter warnings
-//      added require error messages
-//
-pragma solidity ^0.6.0;
+
+pragma solidity ^0.5.0;
+
 library Pairing {
+
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
     struct G1Point {
-        uint X;
-        uint Y;
+        uint256 X;
+        uint256 Y;
     }
+
     // Encoding of field elements is: X[0] * z + X[1]
     struct G2Point {
-        uint[2] X;
-        uint[2] Y;
+        uint256[2] X;
+        uint256[2] Y;
     }
-    /// @return the generator of G1
-    function P1() internal pure returns (G1Point memory) {
-        return G1Point(1, 2);
-    }
-    /// @return the generator of G2
-    function P2() internal pure returns (G2Point memory) {
-        // Original code point
-        return G2Point(
-            [11559732032986387107991004021392285783925812861821192530917403151452391805634,
-             10857046999023057135944570762232829481370756359578518086990519993285655852781],
-            [4082367875863433681332203403145435568316851327593401208105741076214120093531,
-             8495653923123431417604973247489272438418190587263600148770280649306958101930]
-        );
 
-/*
-        // Changed by Jordi point
-        return G2Point(
-            [10857046999023057135944570762232829481370756359578518086990519993285655852781,
-             11559732032986387107991004021392285783925812861821192530917403151452391805634],
-            [8495653923123431417604973247489272438418190587263600148770280649306958101930,
-             4082367875863433681332203403145435568316851327593401208105741076214120093531]
-        );
-*/
-    }
-    /// @return the negation of p, i.e. p.addition(p.negate()) should be zero.
+    /*
+     * @return The negation of p, i.e. p.plus(p.negate()) should be zero. 
+     */
     function negate(G1Point memory p) internal pure returns (G1Point memory) {
+
         // The prime q in the base field F_q for G1
-        uint q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
-        if (p.X == 0 && p.Y == 0)
+        if (p.X == 0 && p.Y == 0) {
             return G1Point(0, 0);
-        return G1Point(p.X, q - (p.Y % q));
+        } else {
+            return G1Point(p.X, PRIME_Q - (p.Y % PRIME_Q));
+        }
     }
-    /// @return r the sum of two points of G1
-    function addition(G1Point memory p1, G1Point memory p2) internal view returns (G1Point memory r) {
-        uint[4] memory input;
+
+    /*
+     * @return The sum of two points of G1
+     */
+    function plus(
+        G1Point memory p1,
+        G1Point memory p2
+    ) internal view returns (G1Point memory r) {
+
+        uint256[4] memory input;
         input[0] = p1.X;
         input[1] = p1.Y;
         input[2] = p2.X;
         input[3] = p2.Y;
         bool success;
+
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+            success := staticcall(sub(gas, 2000), 6, input, 0xc0, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
+
         require(success,"pairing-add-failed");
     }
-    /// @return r the product of a point on G1 and a scalar, i.e.
-    /// p == p.scalar_mul(1) and p.addition(p) == p.scalar_mul(2) for all points p.
-    function scalar_mul(G1Point memory p, uint s) internal view returns (G1Point memory r) {
-        uint[3] memory input;
+
+    /*
+     * @return The product of a point on G1 and a scalar, i.e.
+     *         p == p.scalar_mul(1) and p.plus(p) == p.scalar_mul(2) for all
+     *         points p.
+     */
+    function scalar_mul(G1Point memory p, uint256 s) internal view returns (G1Point memory r) {
+
+        uint256[3] memory input;
         input[0] = p.X;
         input[1] = p.Y;
         input[2] = s;
         bool success;
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+            success := staticcall(sub(gas, 2000), 7, input, 0x80, r, 0x60)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
         require (success,"pairing-mul-failed");
     }
-    /// @return the result of computing the pairing check
-    /// e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
-    /// For example pairing([P1(), P1().negate()], [P2(), P2()]) should
-    /// return true.
-    function pairing(G1Point[] memory p1, G2Point[] memory p2) internal view returns (bool) {
-        require(p1.length == p2.length,"pairing-lengths-failed");
-        uint elements = p1.length;
-        uint inputSize = elements * 6;
-        uint[] memory input = new uint[](inputSize);
-        for (uint i = 0; i < elements; i++)
-        {
-            input[i * 6 + 0] = p1[i].X;
-            input[i * 6 + 1] = p1[i].Y;
-            input[i * 6 + 2] = p2[i].X[0];
-            input[i * 6 + 3] = p2[i].X[1];
-            input[i * 6 + 4] = p2[i].Y[0];
-            input[i * 6 + 5] = p2[i].Y[1];
+
+    /* @return The result of computing the pairing check
+     *         e(p1[0], p2[0]) *  .... * e(p1[n], p2[n]) == 1
+     *         For example,
+     *         pairing([P1(), P1().negate()], [P2(), P2()]) should return true.
+     */
+    function pairing(
+        G1Point memory a1,
+        G2Point memory a2,
+        G1Point memory b1,
+        G2Point memory b2,
+        G1Point memory c1,
+        G2Point memory c2,
+        G1Point memory d1,
+        G2Point memory d2
+    ) internal view returns (bool) {
+
+        G1Point[4] memory p1 = [a1, b1, c1, d1];
+        G2Point[4] memory p2 = [a2, b2, c2, d2];
+
+        uint256 inputSize = 24;
+        uint256[] memory input = new uint256[](inputSize);
+
+        for (uint256 i = 0; i < 4; i++) {
+            uint256 j = i * 6;
+            input[j + 0] = p1[i].X;
+            input[j + 1] = p1[i].Y;
+            input[j + 2] = p2[i].X[0];
+            input[j + 3] = p2[i].X[1];
+            input[j + 4] = p2[i].Y[0];
+            input[j + 5] = p2[i].Y[1];
         }
-        uint[1] memory out;
+
+        uint256[1] memory out;
         bool success;
+
         // solium-disable-next-line security/no-inline-assembly
         assembly {
-            success := staticcall(sub(gas(), 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
+            success := staticcall(sub(gas, 2000), 8, add(input, 0x20), mul(inputSize, 0x20), out, 0x20)
             // Use "invalid" to make gas estimation work
             switch success case 0 { invalid() }
         }
+
         require(success,"pairing-opcode-failed");
+
         return out[0] != 0;
     }
-    /// Convenience method for a pairing check for two pairs.
-    function pairingProd2(G1Point memory a1, G2Point memory a2, G1Point memory b1, G2Point memory b2) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](2);
-        G2Point[] memory p2 = new G2Point[](2);
-        p1[0] = a1;
-        p1[1] = b1;
-        p2[0] = a2;
-        p2[1] = b2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for three pairs.
-    function pairingProd3(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](3);
-        G2Point[] memory p2 = new G2Point[](3);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        return pairing(p1, p2);
-    }
-    /// Convenience method for a pairing check for four pairs.
-    function pairingProd4(
-            G1Point memory a1, G2Point memory a2,
-            G1Point memory b1, G2Point memory b2,
-            G1Point memory c1, G2Point memory c2,
-            G1Point memory d1, G2Point memory d2
-    ) internal view returns (bool) {
-        G1Point[] memory p1 = new G1Point[](4);
-        G2Point[] memory p2 = new G2Point[](4);
-        p1[0] = a1;
-        p1[1] = b1;
-        p1[2] = c1;
-        p1[3] = d1;
-        p2[0] = a2;
-        p2[1] = b2;
-        p2[2] = c2;
-        p2[3] = d2;
-        return pairing(p1, p2);
-    }
 }
+
 contract Verifier {
+
     using Pairing for *;
+
+    uint256 constant SNARK_SCALAR_FIELD = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    uint256 constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
+
     struct VerifyingKey {
         Pairing.G1Point alfa1;
         Pairing.G2Point beta2;
         Pairing.G2Point gamma2;
         Pairing.G2Point delta2;
-        Pairing.G1Point[] IC;
+        Pairing.G1Point[<%vk_ic_length%>] IC;
     }
+
     struct Proof {
         Pairing.G1Point A;
         Pairing.G2Point B;
         Pairing.G1Point C;
     }
+
     function verifyingKey() internal pure returns (VerifyingKey memory vk) {
         vk.alfa1 = Pairing.G1Point(<%vk_alfa1%>);
         vk.beta2 = Pairing.G2Point(<%vk_beta2%>);
         vk.gamma2 = Pairing.G2Point(<%vk_gamma2%>);
         vk.delta2 = Pairing.G2Point(<%vk_delta2%>);
-        vk.IC = new Pairing.G1Point[](<%vk_ic_length%>);
         <%vk_ic_pts%>
     }
-    function verify(Proof memory proof, uint[<%vk_input_length%>] memory input) internal view returns (bool) {
-        uint256 snark_scalar_field = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+    
+    /*
+     * @returns Whether the proof is valid given the hardcoded verifying key
+     *          above and the public inputs
+     */
+    function verifyProof(
+        uint256[2] memory a,
+        uint256[2][2] memory b,
+        uint256[2] memory c,
+        uint256[<%vk_input_length%>] memory input
+    ) public view returns (bool r) {
+
+        Proof memory proof;
+        proof.A = Pairing.G1Point(a[0], a[1]);
+        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
+        proof.C = Pairing.G1Point(c[0], c[1]);
+
         VerifyingKey memory vk = verifyingKey();
-        require(input.length + 1 == vk.IC.length, "verifier-bad-input");
+
+        require(<%vk_ic_length%> == vk.IC.length, "verifier-invalid-input-length");
+
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-        vk_x = Pairing.addition(vk_x, vk.IC[0]);
-        for (uint i = 0; i < input.length; i++) {
-            require(input[i] < snark_scalar_field, "verifier-gte-snark-scalar-field");
-            vk_x = Pairing.addition(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
+
+        // Make sure that proof.A, B, and C are each less than the prime q
+        require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
+        require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
+
+        require(proof.B.X[0] < PRIME_Q, "verifier-cX0-gte-prime-q");
+        require(proof.B.Y[0] < PRIME_Q, "verifier-cY0-gte-prime-q");
+
+        require(proof.B.X[1] < PRIME_Q, "verifier-cX1-gte-prime-q");
+        require(proof.B.Y[1] < PRIME_Q, "verifier-cY1-gte-prime-q");
+
+        require(proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
+        require(proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
+
+        // Make sure that every input is less than the snark scalar field
+        for (uint256 i = 0; i < input.length; i++) {
+            require(input[i] < SNARK_SCALAR_FIELD,"verifier-gte-snark-scalar-field");
+            vk_x = Pairing.plus(vk_x, Pairing.scalar_mul(vk.IC[i + 1], input[i]));
         }
-        return Pairing.pairingProd4(
-            Pairing.negate(proof.A), proof.B,
-            vk.alfa1, vk.beta2,
-            vk_x, vk.gamma2,
-            proof.C, vk.delta2
+
+        vk_x = Pairing.plus(vk_x, vk.IC[0]);
+
+        return Pairing.pairing(
+            Pairing.negate(proof.A),
+            proof.B,
+            vk.alfa1,
+            vk.beta2,
+            vk_x,
+            vk.gamma2,
+            proof.C,
+            vk.delta2
         );
     }
-    function verifyProof(
-            uint[2] memory a,
-            uint[2][2] memory b,
-            uint[2] memory c,
-            uint[<%vk_input_length%>] memory input
-        ) public view returns (bool) {
-        Proof memory _proof;
-        _proof.A = Pairing.G1Point(a[0], a[1]);
-        _proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        _proof.C = Pairing.G1Point(c[0], c[1]);
-        return verify(_proof, input);
-    }
-    function verifyProof(
-            bytes memory proof,
-            uint[<%vk_input_length%>] memory input
-        ) public view returns (bool) {
-        uint[8] memory p = abi.decode(proof, (uint[8]));
-        Proof memory _proof;
-        _proof.A = Pairing.G1Point(p[0], p[1]);
-        _proof.B = Pairing.G2Point([p[2], p[3]], [p[4], p[5]]);
-        _proof.C = Pairing.G1Point(p[6], p[7]);
-        return verify(_proof, input);
-    }
 }
+

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -135,7 +135,7 @@ library Pairing {
             switch success case 0 { invalid() }
         }
 
-        require(success,"pairing-opcode-failed");
+        require(success, "pairing-opcode-failed");
 
         return out[0] != 0;
     }
@@ -181,6 +181,11 @@ contract Verifier {
 
         uint256[8] memory p = abi.decode(proof, (uint256[8]));
 
+        // Make sure that each element in the proof is less than the prime q
+        for (uint8 i = 0; i < p.length; i++) {
+            require(p[i] < PRIME_Q, "verifier-proof-element-gte-prime-q");
+        }
+
         Proof memory _proof;
         _proof.A = Pairing.G1Point(p[0], p[1]);
         _proof.B = Pairing.G2Point([p[2], p[3]], [p[4], p[5]]);
@@ -188,23 +193,8 @@ contract Verifier {
 
         VerifyingKey memory vk = verifyingKey();
 
-        require(<%vk_ic_length%> == vk.IC.length, "verifier-invalid-input-length");
-
         // Compute the linear combination vk_x
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
-
-        // Make sure that proof.A, B, and C are each less than the prime q
-        require(_proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
-        require(_proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
-
-        require(_proof.B.X[0] < PRIME_Q, "verifier-cX0-gte-prime-q");
-        require(_proof.B.Y[0] < PRIME_Q, "verifier-cY0-gte-prime-q");
-
-        require(_proof.B.X[1] < PRIME_Q, "verifier-cX1-gte-prime-q");
-        require(_proof.B.Y[1] < PRIME_Q, "verifier-cY1-gte-prime-q");
-
-        require(_proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
-        require(_proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
 
         // Make sure that every input is less than the snark scalar field
         for (uint256 i = 0; i < input.length; i++) {

--- a/phase2/src/verifier_groth.sol
+++ b/phase2/src/verifier_groth.sol
@@ -175,16 +175,16 @@ contract Verifier {
      *          above and the public inputs
      */
     function verifyProof(
-        uint256[2] memory a,
-        uint256[2][2] memory b,
-        uint256[2] memory c,
+        bytes memory proof,
         uint256[<%vk_input_length%>] memory input
     ) public view returns (bool r) {
 
-        Proof memory proof;
-        proof.A = Pairing.G1Point(a[0], a[1]);
-        proof.B = Pairing.G2Point([b[0][0], b[0][1]], [b[1][0], b[1][1]]);
-        proof.C = Pairing.G1Point(c[0], c[1]);
+        uint256[8] memory p = abi.decode(proof, (uint256[8]));
+
+        Proof memory _proof;
+        _proof.A = Pairing.G1Point(p[0], p[1]);
+        _proof.B = Pairing.G2Point([p[2], p[3]], [p[4], p[5]]);
+        _proof.C = Pairing.G1Point(p[6], p[7]);
 
         VerifyingKey memory vk = verifyingKey();
 
@@ -194,17 +194,17 @@ contract Verifier {
         Pairing.G1Point memory vk_x = Pairing.G1Point(0, 0);
 
         // Make sure that proof.A, B, and C are each less than the prime q
-        require(proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
-        require(proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
+        require(_proof.A.X < PRIME_Q, "verifier-aX-gte-prime-q");
+        require(_proof.A.Y < PRIME_Q, "verifier-aY-gte-prime-q");
 
-        require(proof.B.X[0] < PRIME_Q, "verifier-cX0-gte-prime-q");
-        require(proof.B.Y[0] < PRIME_Q, "verifier-cY0-gte-prime-q");
+        require(_proof.B.X[0] < PRIME_Q, "verifier-cX0-gte-prime-q");
+        require(_proof.B.Y[0] < PRIME_Q, "verifier-cY0-gte-prime-q");
 
-        require(proof.B.X[1] < PRIME_Q, "verifier-cX1-gte-prime-q");
-        require(proof.B.Y[1] < PRIME_Q, "verifier-cY1-gte-prime-q");
+        require(_proof.B.X[1] < PRIME_Q, "verifier-cX1-gte-prime-q");
+        require(_proof.B.Y[1] < PRIME_Q, "verifier-cY1-gte-prime-q");
 
-        require(proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
-        require(proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
+        require(_proof.C.X < PRIME_Q, "verifier-cX-gte-prime-q");
+        require(_proof.C.Y < PRIME_Q, "verifier-cY-gte-prime-q");
 
         // Make sure that every input is less than the snark scalar field
         for (uint256 i = 0; i < input.length; i++) {
@@ -215,13 +215,13 @@ contract Verifier {
         vk_x = Pairing.plus(vk_x, vk.IC[0]);
 
         return Pairing.pairing(
-            Pairing.negate(proof.A),
-            proof.B,
+            Pairing.negate(_proof.A),
+            _proof.B,
             vk.alfa1,
             vk.beta2,
             vk_x,
             vk.gamma2,
-            proof.C,
+            _proof.C,
             vk.delta2
         );
     }


### PR DESCRIPTION
This PR is for https://github.com/kobigurk/phase2-bn254/pull/8 as well. The changes are that `verifier_groth.sol` was audited by ABDK consulting and all the major issues were fixed.

The code in `circom_circuit.rs` which performs the template generation also casts the VK values to `uint256`. This fixes a bug where sometimes part of the generated verifying key might be lower than 248 bits and Solidity complains about the lack of an explicit typecast.

More info about this version of the contract is here: https://github.com/iden3/snarkjs/pull/36